### PR TITLE
Trim whitespace in oracle query

### DIFF
--- a/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
@@ -14,7 +14,7 @@ fun DatabaseInterface.hentPartnerInformasjon(
                     """
                 SELECT partner.partner_id
                 FROM $databasePrefix.PARTNER partner
-                WHERE partner.her_id=?
+                WHERE TRIM(partner.her_id)=?
                 """
             ).use {
                 it.setString(1, herid)


### PR DESCRIPTION
Emottak sometimes has leading and/or trailing whitespace in her_id string column, which results in false misses. 