### PR TITLE
Distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM navikt/java:17
-COPY init.sh /init-scripts/init.sh
+FROM gcr.io/distroless/java17
+WORKDIR /app
 COPY build/libs/app.jar app.jar
-ENV JAVA_OPTS="-Dlogback.configurationFile=logback.xml"
+ENV JDK_JAVA_OPTIONS=" -XX:MaxRAMPercentage=75 -Dlogback.configurationFile=logback.xml -Dhttp.proxyHost=webproxy.nais -Dhttps.proxyHost=webproxy.nais -Dhttp.proxyPort=8088 -Dhttps.proxyPort=8088 -Dhttp.nonProxyHosts=localhost|127.0.0.1|10.254.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*.nais.io|*.aivencloud.com|*.intern.dev.nav.no"
+ENV TZ="Europe/Oslo"
+EXPOSE 8080
+USER nonroot
+CMD [ "app.jar" ]

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -27,7 +27,7 @@ fun main() {
 
     val database = Database(environment)
 
-    val partnerInformasjonService = PartnerInformasjonService(database, environment.databasePrefix)
+    val partnerInformasjonService = PartnerInformasjonService(database)
 
     val server = embeddedServer(Netty, environment.applicationPort) {
         apiModule(

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -14,7 +14,6 @@ data class Environment(
     val azureOpenIdConfigIssuer: String = getEnvVar("AZURE_OPENID_CONFIG_ISSUER"),
 
     val databaseUrl: String = readDBConfig("jdbc_url"),
-    val databasePrefix: String = "", // readDBConfig("DATABASE_PREFIX"),
     val databaseUsername: String = readDBCred("username"),
     val databasePassword: String = readDBCred("password"),
 )

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -23,10 +23,10 @@ fun getEnvVar(varName: String, defaultValue: String? = null) =
     System.getenv(varName) ?: defaultValue ?: throw RuntimeException("Missing required variable \"$varName\"")
 
 fun readDBConfig(envVar: String) =
-        Paths.get("/secrets/oracle/config/$envVar")
-            .takeIf { it.exists() }
-            ?.let { Files.readString(it) }
-            ?: "not found"
+    Paths.get("/secrets/oracle/config/$envVar")
+        .takeIf { it.exists() }
+        ?.let { Files.readString(it) }
+        ?: "not found"
 
 fun readDBCred(envVar: String) =
     Paths.get("/secrets/oracle/creds/$envVar")

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -13,10 +13,10 @@ data class Environment(
     val azureOpenIdConfigJwksUri: String = getEnvVar("AZURE_OPENID_CONFIG_JWKS_URI"),
     val azureOpenIdConfigIssuer: String = getEnvVar("AZURE_OPENID_CONFIG_ISSUER"),
 
-    val databaseUrl: String = readDBConfig("EMOTTAK_JDBC_URL"),
-    val databasePrefix: String = readDBConfig("DATABASE_PREFIX"),
-    val databaseUsername: String = readDBCred("EMOTTAK_USERNAME"),
-    val databasePassword: String = readDBCred("EMOTTAK_PASSWORD"),
+    val databaseUrl: String = readDBConfig("jdbc_url"),
+    val databasePrefix: String = "", // readDBConfig("DATABASE_PREFIX"),
+    val databaseUsername: String = readDBCred("username"),
+    val databasePassword: String = readDBCred("password"),
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -1,5 +1,9 @@
 package no.nav.syfo
 
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.io.path.exists
+
 data class Environment(
     val applicationPort: Int = getEnvVar("APPLICATION_PORT", "8080").toInt(),
     val applicationThreads: Int = getEnvVar("APPLICATION_THREADS", "1").toInt(),
@@ -9,11 +13,23 @@ data class Environment(
     val azureOpenIdConfigJwksUri: String = getEnvVar("AZURE_OPENID_CONFIG_JWKS_URI"),
     val azureOpenIdConfigIssuer: String = getEnvVar("AZURE_OPENID_CONFIG_ISSUER"),
 
-    val databaseUrl: String = getEnvVar("EMOTTAK_JDBC_URL"),
-    val databasePrefix: String = getEnvVar("DATABASE_PREFIX"),
-    val databaseUsername: String = getEnvVar("EMOTTAK_USERNAME"),
-    val databasePassword: String = getEnvVar("EMOTTAK_PASSWORD"),
+    val databaseUrl: String = readDBConfig("EMOTTAK_JDBC_URL"),
+    val databasePrefix: String = readDBConfig("DATABASE_PREFIX"),
+    val databaseUsername: String = readDBCred("EMOTTAK_USERNAME"),
+    val databasePassword: String = readDBCred("EMOTTAK_PASSWORD"),
 )
 
 fun getEnvVar(varName: String, defaultValue: String? = null) =
     System.getenv(varName) ?: defaultValue ?: throw RuntimeException("Missing required variable \"$varName\"")
+
+fun readDBConfig(envVar: String) =
+        Paths.get("/secrets/oracle/config/$envVar")
+            .takeIf { it.exists() }
+            ?.let { Files.readString(it) }
+            ?: "not found"
+
+fun readDBCred(envVar: String) =
+    Paths.get("/secrets/oracle/creds/$envVar")
+        .takeIf { it.exists() }
+        ?.let { Files.readString(it) }
+        ?: "not found"

--- a/src/main/kotlin/no/nav/syfo/aksessering/api/BehandlerApiV2.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/api/BehandlerApiV2.kt
@@ -28,7 +28,10 @@ fun Route.registerBehandlerApiV2(
                     call.respond(emptyList<PartnerInformasjon>())
                 }
                 else -> {
-                    call.respond(partnerInformasjonService.finnPartnerInformasjon(herid))
+                    val partnerInfo = partnerInformasjonService.finnPartnerInformasjon(herid)
+                    val partnerId = partnerInfo.firstOrNull()?.partnerId
+                    log.info("Fant partnerInformasjon for aktuell herid: $herid partnerId: $partnerId")
+                    call.respond(partnerInfo)
                 }
             }
         }

--- a/src/main/kotlin/no/nav/syfo/aksessering/api/BehandlerApiV2.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/api/BehandlerApiV2.kt
@@ -18,19 +18,15 @@ fun Route.registerBehandlerApiV2(
     route(v2BasePath) {
         get(behandlerV2BasePath) {
             val herid = call.request.queryParameters[behandlerV2QueryParamHerid]
-            when {
-                herid.isNullOrEmpty() -> {
-                    log.info("Mangler query parameters: herid")
-                    call.respond(HttpStatusCode.BadRequest)
-                }
-                partnerInformasjonService.finnPartnerInformasjon(herid).isEmpty() -> {
+            if (herid.isNullOrEmpty()) {
+                log.info("Mangler query parameters: herid")
+                call.respond(HttpStatusCode.BadRequest)
+            } else {
+                val partnerInfo = partnerInformasjonService.finnPartnerInformasjon(herid)
+                if (partnerInfo.isEmpty()) {
                     log.info("Fant ingen partnerInformasjon for aktuell herid: $herid")
                     call.respond(emptyList<PartnerInformasjon>())
-                }
-                else -> {
-                    val partnerInfo = partnerInformasjonService.finnPartnerInformasjon(herid)
-                    val partnerId = partnerInfo.firstOrNull()?.partnerId
-                    log.info("Fant partnerInformasjon for aktuell herid: $herid partnerId: $partnerId")
+                } else {
                     call.respond(partnerInfo)
                 }
             }

--- a/src/main/kotlin/no/nav/syfo/aksessering/db/ElektroniskAbonomentQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/ElektroniskAbonomentQueries.kt
@@ -13,7 +13,7 @@ fun DatabaseInterface.hentElektroniskAbonoment(
         connection.prepareStatement(
             """
                 SELECT partner.partner_id
-                FROM $databasePrefix.PARTNER partner, $databasePrefix.ABONNEMENT abonnement
+                FROM PARTNER partner, ABONNEMENT abonnement
                 WHERE partner.PARTNER_ID = abonnement.PARTNER_ID
                 AND abonnement.tjeneste_id = '3'
                 AND (abonnement.SLUTT_DATO > sysdate or abonnement.SLUTT_DATO is NULL)

--- a/src/main/kotlin/no/nav/syfo/aksessering/db/ElektroniskAbonomentQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/ElektroniskAbonomentQueries.kt
@@ -7,7 +7,6 @@ import java.sql.ResultSet
 
 fun DatabaseInterface.hentElektroniskAbonoment(
     herid: String,
-    databasePrefix: String
 ): List<ElektroniskAbonoment> =
     connection.use { connection ->
         connection.prepareStatement(

--- a/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
@@ -13,7 +13,7 @@ fun DatabaseInterface.hentPartnerInformasjon(
         connection.prepareStatement(
             """
                 SELECT partner.partner_id
-                FROM $databasePrefix.PARTNER partner
+                FROM PARTNER partner
                 WHERE TRIM(partner.her_id)=?
                 """
         ).use {

--- a/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/PartnerInformasjonQueries.kt
@@ -7,7 +7,6 @@ import java.sql.ResultSet
 
 fun DatabaseInterface.hentPartnerInformasjon(
     herid: String,
-    databasePrefix: String
 ): List<PartnerInformasjon> =
     connection.use { connection ->
         connection.prepareStatement(

--- a/src/main/kotlin/no/nav/syfo/services/ElektroniskAbonomentService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/ElektroniskAbonomentService.kt
@@ -7,5 +7,5 @@ class ElektroniskAbonomentService(
     private val database: DatabaseInterface,
     private val databasePrefix: String,
 ) {
-    fun finnParnterInformasjon(herid: String): List<ElektroniskAbonoment> = database.hentElektroniskAbonoment(herid, databasePrefix)
+    fun finnParnterInformasjon(herid: String): List<ElektroniskAbonoment> = database.hentElektroniskAbonoment(herid)
 }

--- a/src/main/kotlin/no/nav/syfo/services/PartnerInformasjonService.kt
+++ b/src/main/kotlin/no/nav/syfo/services/PartnerInformasjonService.kt
@@ -5,10 +5,9 @@ import no.nav.syfo.db.DatabaseInterface
 
 class PartnerInformasjonService(
     private val database: DatabaseInterface,
-    private val databasePrefix: String,
 ) {
     fun finnPartnerInformasjon(
         herid: String,
     ): List<PartnerInformasjon> =
-        database.hentPartnerInformasjon(herid, databasePrefix)
+        database.hentPartnerInformasjon(herid)
 }

--- a/src/test/kotlin/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/testhelper/TestEnvironment.kt
@@ -29,7 +29,6 @@ fun testEnvironment() = Environment(
     azureOpenIdConfigJwksUri = "azureOpenIdConfigJwksUri",
     azureOpenIdConfigIssuer = "azureOpenIdConfigIssuer",
     databaseUrl = "",
-    databasePrefix = "",
     databaseUsername = "",
     databasePassword = ""
 )


### PR DESCRIPTION
Bruk distroless image for å løse sårbarheter i gammelt base-image.

For å få til dette til å kjøre onprem: 

1. Må legge til en del proxy-konfig i docker-fila.
2. Må lese Vault-params på en annen måte.