### PR TITLE
IS-3348: Erstattet bruk av kotlin.test.asserts med JUnit

### DIFF
--- a/src/test/kotlin/SelfTest.kt
+++ b/src/test/kotlin/SelfTest.kt
@@ -5,10 +5,10 @@ import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.api.registerNaisApi
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class SelfTest {
 

--- a/src/test/kotlin/api/BehandlerApiV2Test.kt
+++ b/src/test/kotlin/api/BehandlerApiV2Test.kt
@@ -10,10 +10,10 @@ import io.mockk.mockk
 import no.nav.syfo.aksessering.api.*
 import no.nav.syfo.application.API_BASE_PATH
 import no.nav.syfo.services.PartnerInformasjonService
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import testhelper.testApiModule
 import testhelper.testEnvironment
-import kotlin.test.assertEquals
 
 class BehandlerApiV2Test {
     private val partnerInformasjonService = mockk<PartnerInformasjonService>()


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Ved overgang til JUnit i tidligere [PR](https://github.com/navikt/syfopartnerinfo/pull/81) så ble `kotlin.test.asserts` feilaktig lagt til i stedet for JUnit.
